### PR TITLE
Masking table names with special characters to avoid 400 Bad Request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ninoxjs",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ninoxjs",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,13 +19,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
+        "version": "1.7.2",
+        "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+        "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+        "dependencies": {
+            "follow-redirects": "^1.15.6",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+        }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ninoxjs",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "a simple and fast wrapper for the Ninox API, allows executing and querying with NXScript and the REST API",
   "main": "index.js",
   "repository": "https://github.com/AxelRothe/ninox",
@@ -18,7 +18,7 @@
   "author": "Axel Rothe <hello@axelrothe.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.27.2",
+    "axios": "^1.7.2",
     "dotenv": "^16.0.3"
   }
 }

--- a/src/ninox.js
+++ b/src/ninox.js
@@ -178,7 +178,7 @@ class Ninox {
 		const response = await axios.get(
 			`${this.uri}/v${this.version}/teams/${this.teamId}/databases/${
 				this.databaseId
-			}/tables/${table}/records?pages=9999&perPage=9999&filters=${encodeURIComponent(
+			}/tables/${encodeURIComponent(table)}/records?pages=9999&perPage=9999&filters=${encodeURIComponent(
 				JSON.stringify({ fields: filters })
 			)}`,
 			{
@@ -218,7 +218,7 @@ class Ninox {
 		if (!this.databaseId || !this.teamId) throw new Error("Database and team are required. Call auth() first");
 
 		const response = await axios.get(
-			`${this.uri}/v${this.version}/teams/${this.teamId}/databases/${this.databaseId}/tables/${table}/records/${id}`,
+			`${this.uri}/v${this.version}/teams/${this.teamId}/databases/${this.databaseId}/tables/${encodeURIComponent(table)}/records/${id}`,
 			{
 				method: "get",
 				headers: {
@@ -282,7 +282,7 @@ class Ninox {
 		if (!this.databaseId || !this.teamId) throw new Error("Database and team are required. Call auth() first");
 
 		const result = await axios.post(
-			`${this.uri}/v${this.version}/teams/${this.teamId}/databases/${this.databaseId}/tables/${table}/records`,
+			`${this.uri}/v${this.version}/teams/${this.teamId}/databases/${this.databaseId}/tables/${encodeURIComponent(table)}/records`,
 			records,
 			{
 				headers: {
@@ -309,7 +309,7 @@ class Ninox {
 		if (!this.databaseId || !this.teamId) throw new Error("Database and team are required. Call auth() first");
 
 		const result = await axios.delete(
-			`${this.uri}/v${this.version}/teams/${this.teamId}/databases/${this.databaseId}/tables/${table}/records/${id}`,
+			`${this.uri}/v${this.version}/teams/${this.teamId}/databases/${this.databaseId}/tables/${encodeURIComponent(table)}/records/${id}`,
 			{
 				headers: {
 					"Content-Type": "application/json",


### PR DESCRIPTION
Added encodeURIComponent() to the URLs with table names in them because you would get 400 Bad Request errors when the names contain special characters like ä, ö, è, etc.